### PR TITLE
Add POST method to CORS configuration file given the way AWS.S3 upload manager for Javascript works

### DIFF
--- a/04-Infrastructure/01-Policies/01-Bucket/cors_configuration.xml
+++ b/04-Infrastructure/01-Policies/01-Bucket/cors_configuration.xml
@@ -4,12 +4,14 @@
         <AllowedOrigin>http://rva.proof.ofconcept.help</AllowedOrigin>
         <AllowedMethod>GET</AllowedMethod>
         <AllowedMethod>PUT</AllowedMethod>
+        <AllowedMethod>POST</AllowedMethod>
         <AllowedHeader>*</AllowedHeader>
     </CORSRule>
     <CORSRule>
         <AllowedOrigin>https://rva.proof.ofconcept.help</AllowedOrigin>
         <AllowedMethod>GET</AllowedMethod>
         <AllowedMethod>PUT</AllowedMethod>
+        <AllowedMethod>POST</AllowedMethod>
         <AllowedHeader>*</AllowedHeader>
     </CORSRule>
 </CORSConfiguration>


### PR DESCRIPTION
Add POST method to CORS configuration file given the way AWS.S3 upload manager for Javascript works